### PR TITLE
feat: add current User macro

### DIFF
--- a/.changeset/fifty-windows-fry.md
+++ b/.changeset/fifty-windows-fry.md
@@ -2,4 +2,17 @@
 "elysia-clerk": minor
 ---
 
-Add current User macro
+Add `currentUser` macro for getting the current authenticated user.
+
+Usage:
+
+```ts
+new Elysia()
+  .use(clerkPlugin())
+  .get('/currentUser', ({ currentUser, error }) => {
+    return { currentUser }
+  }, {
+    currentUser: true
+  })
+  .listen(3000)
+```

--- a/.changeset/fifty-windows-fry.md
+++ b/.changeset/fifty-windows-fry.md
@@ -9,7 +9,11 @@ Usage:
 ```ts
 new Elysia()
   .use(clerkPlugin())
-  .get('/currentUser', ({ currentUser, error }) => {
+  .get('/current-user', ({ currentUser, error }) => {
+    if (!currentUser) {
+      return error(401)
+    }
+
     return { currentUser }
   }, {
     currentUser: true

--- a/.changeset/fifty-windows-fry.md
+++ b/.changeset/fifty-windows-fry.md
@@ -2,7 +2,7 @@
 "elysia-clerk": minor
 ---
 
-Add `currentUser` macro for getting the current authenticated user.
+Add `currentUser` macro to get the [Backend User](https://clerk.com/docs/references/backend/types/backend-user) object of the currently active user.
 
 Usage:
 

--- a/.changeset/fifty-windows-fry.md
+++ b/.changeset/fifty-windows-fry.md
@@ -1,0 +1,5 @@
+---
+"elysia-clerk": minor
+---
+
+Add current User macro

--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ new Elysia()
 
 To see the available options you can pass to the `clerkPlugin` function, see [`AuthenticateRequestOptions`](https://clerk.com/docs/references/backend/authenticate-request#authenticate-request-options).
 
+### Macros
+
+#### `currentUser`
+
+Add `currentUser` macro to get the [Backend User](https://clerk.com/docs/references/backend/types/backend-user) object of the currently active user.
+
+```ts
+new Elysia()
+  .use(clerkPlugin())
+  .get('/api/current-user', ({ currentUser, error }) => {
+    if (!currentUser) {
+      return error(401)
+    }
+
+    return { currentUser }
+  }, {
+    currentUser: true
+  })
+  .listen(3000)
+```
+
 ## License
 
 MIT

--- a/build.ts
+++ b/build.ts
@@ -14,7 +14,7 @@ const defaultBuildConfig: BuildConfig = {
   },
 }
 
-console.log('Building packages...')
+console.log('Building...')
 
 const [mjsBuild, cjsBuild] = await Promise.all([
   // ESM build
@@ -34,8 +34,7 @@ const [mjsBuild, cjsBuild] = await Promise.all([
 ])
 
 if (mjsBuild.success && cjsBuild.success) {
-  console.log('All builds completed successfully!')
+  console.log('Build success')
 } else {
   console.error('Build failed')
-  process.exit(1)
 }

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -19,8 +19,8 @@ export const app = new Elysia()
   .get('/app.js', () => {
     return appContents.replace('REPLACE_ME', process.env.CLERK_PUBLISHABLE_KEY as string)
   })
-  .get('/private', async ({ set, auth, currentUser }) => {
-    if (!auth?.userId) {
+  .get('/private', async ({ set, currentUser }) => {
+    if (!currentUser) {
       set.status = 403
       return 'Unauthorized'
     }

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -19,15 +19,17 @@ export const app = new Elysia()
   .get('/app.js', () => {
     return appContents.replace('REPLACE_ME', process.env.CLERK_PUBLISHABLE_KEY as string)
   })
-  .get('/private', async ({ clerk, set, auth }) => {
+  .get('/private', async ({ set, auth, currentUser }) => {
     if (!auth?.userId) {
       set.status = 403
       return 'Unauthorized'
     }
 
-    const user = await clerk.users.getUser(auth.userId)
-
-    return { user }
+    return {
+      user: currentUser
+    }
+  }, {
+    currentUser: true
   })
   .use(innerRoute)
   .listen(3000)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -63,7 +63,9 @@ export function clerkPlugin(options?: ElysiaClerkOptions) {
 					const auth = requestState.toAuth();
 
 					if (!auth?.userId) {
-						return;
+						return {
+							currentUser: null,
+						};
 					}
 
 					const currentUser = await clerkClient.users.getUser(auth.userId);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,18 +10,23 @@ export function clerkPlugin(options?: ElysiaClerkOptions) {
 	const secretKey = options?.secretKey ?? constants.SECRET_KEY;
 	const publishableKey = options?.publishableKey ?? constants.PUBLISHABLE_KEY;
 
+	async function getRequestState(request: Request) {
+		const requestState = await clerkClient.authenticateRequest(request, {
+			...options,
+			secretKey,
+			publishableKey,
+		});
+
+		return requestState;
+	}
+
 	return new Elysia({
 		name: 'elysia-clerk',
 		seed: options,
 	})
 		.decorate('clerk', clerkClient)
 		.resolve(async ({ request, set }) => {
-			const requestState = await clerkClient.authenticateRequest(request, {
-				...options,
-				secretKey,
-				publishableKey,
-			});
-
+			const requestState = await getRequestState(request);
 			const auth = requestState.toAuth();
 
 			requestState.headers.forEach((value, key) => {
@@ -54,12 +59,7 @@ export function clerkPlugin(options?: ElysiaClerkOptions) {
 						return;
 					}
 
-					const requestState = await clerkClient.authenticateRequest(request, {
-						...options,
-						secretKey,
-						publishableKey,
-					});
-
+					const requestState = await getRequestState(request);
 					const auth = requestState.toAuth();
 
 					if (!auth?.userId) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -47,5 +47,32 @@ export function clerkPlugin(options?: ElysiaClerkOptions) {
 				auth,
 			};
 		})
+		.macro({
+			currentUser: (enabled: true) => ({
+				resolve: async ({ request }) => {
+					if (!enabled) {
+						return;
+					}
+
+					const requestState = await clerkClient.authenticateRequest(request, {
+						...options,
+						secretKey,
+						publishableKey,
+					});
+
+					const auth = requestState.toAuth();
+
+					if (!auth?.userId) {
+						return;
+					}
+
+					const currentUser = await clerkClient.users.getUser(auth.userId);
+
+					return {
+						currentUser,
+					};
+				},
+			}),
+		})
 		.as('plugin');
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleDetection": "force",
     "jsx": "react-jsx",
     "allowJs": true,
+    "allowSyntheticDefaultImports": true,
 
     "moduleResolution": "node",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
This PR adds a `currentUser` macro to get the [Backend User](https://clerk.com/docs/references/backend/types/backend-user) object of the currently active user.

```ts
new Elysia()
  .use(clerkPlugin())
  .get('/currentUser', ({ currentUser, error }) => {
    return { currentUser }
  }, { currentUser: true })
  .listen(3000)
```