### PR TITLE
chore: Expose auth context as function

### DIFF
--- a/.changeset/easy-files-sneeze.md
+++ b/.changeset/easy-files-sneeze.md
@@ -1,0 +1,5 @@
+---
+"elysia-clerk": patch
+---
+
+Deprecate `context.auth` in favor of `context.auth()` as function

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ new Elysia()
      * Access the auth state in the context.
      * See the AuthObject here https://clerk.com/docs/references/nextjs/auth-object#auth-object
      */
-    if (!auth?.userId) {
+    if (!auth()?.userId) {
       return error(401)
     }
 
@@ -41,7 +41,7 @@ new Elysia()
      * For other resource operations, you can use the clerk client from the context.
      * See what other utilities Clerk exposes here https://clerk.com/docs/references/backend/overview
      */
-    const user = await clerkClient.users.getUser(auth.userId)
+    const user = await clerkClient.users.getUser(auth()!.userId)
 
     return { user }
   })

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -20,19 +20,20 @@ export const app = new Elysia()
     return appContents.replace('REPLACE_ME', process.env.CLERK_PUBLISHABLE_KEY as string)
   })
   .get('/private', async ({ set, auth, clerk }) => {
-    if (!auth?.userId) {
+    const authObj = auth()
+    if (!authObj?.userId) {
       set.status = 403
       return 'Unauthorized'
     }
 
-    const user = await clerk.users.getUser(auth.userId)
+    const user = await clerk.users.getUser(authObj.userId)
 
     return {
       user
     }
   })
   .use(innerRoute)
-  .listen(3000)
+  .listen(8080)
 
 console.log(
   `🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`,

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -16,7 +16,7 @@ describe('plugin(options)', () => {
 
 		const app = new Elysia()
 			.use(clerkPlugin())
-			.get('/', (c) => ({ auth: c.auth }));
+			.get('/', (c) => ({ auth: c.auth() }));
 
 		const response = await app.handle(
 			new Request('http://localhost/', {
@@ -52,7 +52,7 @@ describe('plugin(options)', () => {
 
 		const app = new Elysia()
 			.use(clerkPlugin())
-			.get('/', (c) => ({ auth: c.auth }));
+			.get('/', (c) => ({ auth: c.auth() }));
 
 		const response = await app.handle(
 			new Request('http://localhost/', {
@@ -97,7 +97,7 @@ describe('plugin(options)', () => {
 
 		const app = new Elysia()
 			.use(clerkPlugin())
-			.get('/', (c) => ({ auth: c.auth }));
+			.get('/', (c) => ({ auth: c.auth() }));
 
 		const response = await app.handle(
 			new Request('http://localhost/', {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,8 +1,8 @@
 import type { ClerkOptions } from '@clerk/backend';
+import { deprecated } from '@clerk/shared/deprecated';
 import { Elysia } from 'elysia';
 import { clerkClient } from './clerkClient';
 import * as constants from './constants';
-import { deprecated } from '@clerk/shared/deprecated';
 
 export type ElysiaClerkOptions = ClerkOptions;
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,6 +2,7 @@ import type { ClerkOptions } from '@clerk/backend';
 import { Elysia } from 'elysia';
 import { clerkClient } from './clerkClient';
 import * as constants from './constants';
+import { deprecated } from '@clerk/shared/deprecated';
 
 export type ElysiaClerkOptions = ClerkOptions;
 
@@ -23,7 +24,20 @@ export function clerkPlugin(options?: ElysiaClerkOptions) {
 				secretKey,
 				publishableKey,
 			});
-			const auth = requestState.toAuth();
+
+			const authObject = requestState.toAuth();
+			const authHandler = () => authObject;
+
+			const auth = new Proxy(Object.assign(authHandler, authObject), {
+				get(target, prop: string, receiver) {
+					deprecated(
+						'context.auth',
+						'Use `context.auth()` as a function instead.',
+					);
+
+					return Reflect.get(target, prop, receiver);
+				},
+			});
 
 			requestState.headers.forEach((value, key) => {
 				set.headers[key] = value;


### PR DESCRIPTION
Deprecate `context.auth` in favor of `context.auth()` as function